### PR TITLE
Shuffle samples, then batch, to make order independent of batch size

### DIFF
--- a/unicore/data/iterators.py
+++ b/unicore/data/iterators.py
@@ -365,7 +365,7 @@ class EpochBatchIterator(EpochBatchIterating):
                     batches = np.concatenate(batches)
                     np.random.shuffle(batches)
                     batches = np.split(batches, lens[:-1])
-                # shuffles prepacked batchs
+                # shuffles prepacked batches, final order is batch_size dependent
                 else:
                     np.random.shuffle(batches)
             return batches


### PR DESCRIPTION
Currently a `frozen_batches` is kept during shuffling, which makes the samples ordering not independent of batch size, it also defies the purpose of shuffling as some batches will always be the same. 

This might be smart if some batches are of smaller samples than others and the batch size can be dynamically adjusted, but outside that specific scenario, sample-based shuffling seems more correct and helpful during debugging, etc. 

This PR introduces sample-based shuffling as default, and keeps batch-based shuffling as keyword arg to the `EpochBatchIterator`